### PR TITLE
Fix width of timer input

### DIFF
--- a/data/media/app.css
+++ b/data/media/app.css
@@ -398,7 +398,7 @@ hr {
     padding: 6px;
     outline: none;
     text-align: center;
-    width: 59px;
+    max-width: 59px;
     margin: 10px auto;
     background-color: #fff;
     -webkit-user-select: all;

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+up-clock (6.2) focal; urgency=medium
+
+  * Fixed timer input width
+
+ -- Archisman Panigrahi <apandada1@gmail.com>  Fri, 31 Jul 2020 17:27:33 +0530
+
 up-clock (6.1) focal; urgency=medium
 
   * Bump version number. It was worth the hassle

--- a/setup.py
+++ b/setup.py
@@ -137,7 +137,7 @@ class InstallAndUpdateDataDirectory(DistUtilsExtra.auto.install_auto):
 
 DistUtilsExtra.auto.setup(
     name='up-clock',
-    version='6.1',
+    version='6.2',
     license='GPL-3',
     author='Archisman Panigrahi',
     author_email='apandada1@gmail.com',


### PR DESCRIPTION
The input fields in timer were of different width (for weird reason - they worked correctly in firefox)